### PR TITLE
add slot,id,offset columns

### DIFF
--- a/src/csv.rs
+++ b/src/csv.rs
@@ -19,6 +19,9 @@ struct Record {
     owner: String,
     data_len: u64,
     lamports: u64,
+    slot: u64,
+    id: u64,
+    offset: usize,
     write_version: u64,
     data: String,
 }
@@ -36,21 +39,24 @@ impl CsvDumper {
         }
     }
 
-    pub(crate) fn dump_append_vec(&mut self, append_vec: AppendVec) {
+    pub(crate) fn dump_append_vec(&mut self, slot: u64, id: u64, append_vec: AppendVec) {
         for account in append_vec_iter(Rc::new(append_vec)) {
             let account = account.access().unwrap();
             if self.filter.is_match(&account) {
-                self.dump_account(account);
+                self.dump_account(slot, id, account);
             }
         }
     }
 
-    pub(crate) fn dump_account(&mut self, account: StoredAccountMeta) {
+    pub(crate) fn dump_account(&mut self, slot: u64, id: u64, account: StoredAccountMeta) {
         let record = Record {
             pubkey: account.meta.pubkey.to_string(),
             owner: account.account_meta.owner.to_string(),
             data_len: account.meta.data_len,
             lamports: account.account_meta.lamports,
+            slot,
+            id,
+            offset: account.offset,
             write_version: account.meta.write_version,
             data: base64::encode(account.data),
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,11 @@ use crate::filter::AccountFilter;
 use clap::Parser;
 use log::{error, info};
 use reqwest::blocking::Response;
-use solana_snapshot_etl::archived::ArchiveSnapshotExtractor;
-use solana_snapshot_etl::{AppendVecIterator, SnapshotExtractor};
+use modified_solana_snapshot_etl::{AppendVecIterator, SnapshotExtractor, ArchiveSnapshotExtractor};
 use std::fs::{File};
 use std::path::{Path};
+
+mod modified_solana_snapshot_etl;
 
 mod csv;
 mod filter;
@@ -55,7 +56,8 @@ fn _main() -> Result<(), Box<dyn std::error::Error>> {
     let mut processed = 0;
     let mut writer = CsvDumper::new(filter, args.noheader);
     for append_vec in loader.iter() {
-        writer.dump_append_vec(append_vec?);
+        let (slot, id, append_vec) = append_vec?;
+        writer.dump_append_vec(slot, id, append_vec);
 
         processed += 1;
         if processed % 100 == 0 {

--- a/src/modified_solana_snapshot_etl.rs
+++ b/src/modified_solana_snapshot_etl.rs
@@ -1,0 +1,197 @@
+// This file contains code from the solana-snapshot-etl project
+// Source: https://github.com/riptl/solana-snapshot-etl/blob/d1f569b3e9384ba54948d59875da08dfbec4559e/src/archived.rs
+// Source: https://github.com/riptl/solana-snapshot-etl/blob/d1f569b3e9384ba54948d59875da08dfbec4559e/src/lib.rs
+
+use solana_snapshot_etl::{
+    solana::{deserialize_from, AccountsDbFields, DeserializableVersionedBank, SerializableAccountStorageEntry},
+    append_vec::AppendVec, Result, SnapshotError,
+};
+use log::info;
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::{Component, Path};
+use std::pin::Pin;
+use std::time::Instant;
+use tar::{Archive, Entries, Entry};
+use std::ffi::OsStr;
+use std::str::FromStr;
+
+fn parse_append_vec_name(name: &OsStr) -> Option<(u64, u64)> {
+    let name = name.to_str()?;
+    let mut parts = name.splitn(2, '.');
+    let slot = u64::from_str(parts.next().unwrap_or(""));
+    let id = u64::from_str(parts.next().unwrap_or(""));
+    match (slot, id) {
+        (Ok(slot), Ok(version)) => Some((slot, version)),
+        _ => None,
+    }
+}
+
+pub type AppendVecIterator<'a> = Box<dyn Iterator<Item = Result<(u64, u64, AppendVec)>> + 'a>;
+
+pub trait SnapshotExtractor: Sized {
+    fn iter(&mut self) -> AppendVecIterator<'_>;
+}
+
+/// Extracts account data from a .tar.zst stream.
+pub struct ArchiveSnapshotExtractor<Source>
+where
+    Source: Read + Unpin + 'static,
+{
+    accounts_db_fields: AccountsDbFields<SerializableAccountStorageEntry>,
+    _archive: Pin<Box<Archive<zstd::Decoder<'static, BufReader<Source>>>>>,
+    entries: Option<Entries<'static, zstd::Decoder<'static, BufReader<Source>>>>,
+}
+
+impl<Source> SnapshotExtractor for ArchiveSnapshotExtractor<Source>
+where
+    Source: Read + Unpin + 'static,
+{
+    fn iter(&mut self) -> AppendVecIterator<'_> {
+        Box::new(self.unboxed_iter())
+    }
+}
+
+impl<Source> ArchiveSnapshotExtractor<Source>
+where
+    Source: Read + Unpin + 'static,
+{
+    pub fn from_reader(source: Source) -> Result<Self> {
+        let tar_stream = zstd::stream::read::Decoder::new(source)?;
+        let mut archive = Box::pin(Archive::new(tar_stream));
+
+        // This is safe as long as we guarantee that entries never gets accessed past drop.
+        let archive_static = unsafe { &mut *((&mut *archive) as *mut Archive<_>) };
+        let mut entries = archive_static.entries()?;
+
+        // Search for snapshot manifest.
+        let mut snapshot_file: Option<Entry<_>> = None;
+        for entry in entries.by_ref() {
+            let entry = entry?;
+            let path = entry.path()?;
+            if Self::is_snapshot_manifest_file(&path) {
+                snapshot_file = Some(entry);
+                break;
+            } else if Self::is_appendvec_file(&path) {
+                // TODO Support archives where AppendVecs precede snapshot manifests
+                return Err(SnapshotError::UnexpectedAppendVec);
+            }
+        }
+        let snapshot_file = snapshot_file.ok_or(SnapshotError::NoSnapshotManifest)?;
+        //let snapshot_file_len = snapshot_file.size();
+        let snapshot_file_path = snapshot_file.path()?.as_ref().to_path_buf();
+
+        info!("Opening snapshot manifest: {:?}", &snapshot_file_path);
+        let mut snapshot_file = BufReader::new(snapshot_file);
+
+        let pre_unpack = Instant::now();
+        let versioned_bank: DeserializableVersionedBank = deserialize_from(&mut snapshot_file)?;
+        drop(versioned_bank);
+        let versioned_bank_post_time = Instant::now();
+
+        let accounts_db_fields: AccountsDbFields<SerializableAccountStorageEntry> =
+            deserialize_from(&mut snapshot_file)?;
+        let accounts_db_fields_post_time = Instant::now();
+        drop(snapshot_file);
+
+        info!(
+            "Read bank fields in {:?}",
+            versioned_bank_post_time - pre_unpack
+        );
+        info!(
+            "Read accounts DB fields in {:?}",
+            accounts_db_fields_post_time - versioned_bank_post_time
+        );
+
+        Ok(ArchiveSnapshotExtractor {
+            _archive: archive,
+            accounts_db_fields,
+            entries: Some(entries),
+        })
+    }
+
+    fn unboxed_iter(&mut self) -> impl Iterator<Item = Result<(u64, u64, AppendVec)>> + '_ {
+        self.entries
+            .take()
+            .into_iter()
+            .flatten()
+            .filter_map(|entry| {
+                let mut entry = match entry {
+                    Ok(x) => x,
+                    Err(e) => return Some(Err(e.into())),
+                };
+                let path = match entry.path() {
+                    Ok(x) => x,
+                    Err(e) => return Some(Err(e.into())),
+                };
+                let (slot, id) = path.file_name().and_then(parse_append_vec_name)?;
+                Some(self.process_entry(&mut entry, slot, id))
+            })
+    }
+
+    fn process_entry(
+        &self,
+        entry: &mut Entry<'static, zstd::Decoder<'static, BufReader<Source>>>,
+        slot: u64,
+        id: u64,
+    ) -> Result<(u64, u64, AppendVec)> {
+        let known_vecs = self
+            .accounts_db_fields
+            .0
+            .get(&slot)
+            .map(|v| &v[..])
+            .unwrap_or(&[]);
+        let known_vec = known_vecs.iter().find(|entry| entry.id == (id as usize));
+        let known_vec = match known_vec {
+            None => return Err(SnapshotError::UnexpectedAppendVec),
+            Some(v) => v,
+        };
+        let append_vec = AppendVec::new_from_reader(
+            entry,
+            known_vec.accounts_current_len,
+        )?;
+        Ok((slot, id, append_vec))
+    }
+
+    fn is_snapshot_manifest_file(path: &Path) -> bool {
+        let mut components = path.components();
+        if components.next() != Some(Component::Normal("snapshots".as_ref())) {
+            return false;
+        }
+        let slot_number_str_1 = match components.next() {
+            Some(Component::Normal(slot)) => slot,
+            _ => return false,
+        };
+        // Check if slot number file is valid u64.
+        if slot_number_str_1
+            .to_str()
+            .and_then(|s| s.parse::<u64>().ok())
+            .is_none()
+        {
+            return false;
+        }
+        let slot_number_str_2 = match components.next() {
+            Some(Component::Normal(slot)) => slot,
+            _ => return false,
+        };
+        components.next().is_none() && slot_number_str_1 == slot_number_str_2
+    }
+
+    fn is_appendvec_file(path: &Path) -> bool {
+        let mut components = path.components();
+        if components.next() != Some(Component::Normal("accounts".as_ref())) {
+            return false;
+        }
+        let name = match components.next() {
+            Some(Component::Normal(c)) => c,
+            _ => return false,
+        };
+        components.next().is_none() && parse_append_vec_name(name).is_some()
+    }
+}
+
+impl ArchiveSnapshotExtractor<File> {
+    pub fn open(path: &Path) -> Result<Self> {
+        Self::from_reader(File::open(path)?)
+    }
+}


### PR DESCRIPTION
write_version no longer works well in recent snapshot files.
Now each slot has only one AppendVec file, so we can use slot and offset to determine the latest account state.

For compatibility purpose, I didn't remove write_version columns. (for old snapshot files)